### PR TITLE
persist torrent progress to disk

### DIFF
--- a/bitmap.storage.go
+++ b/bitmap.storage.go
@@ -1,0 +1,75 @@
+package torrent
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/RoaringBitmap/roaring/v2"
+	"github.com/james-lawrence/torrent/dht/int160"
+	"github.com/james-lawrence/torrent/internal/errorsx"
+)
+
+type BitmapStore interface {
+	Delete(id int160.T) error
+	Read(id int160.T) (*roaring.Bitmap, error)
+	Write(id int160.T, bm *roaring.Bitmap) error
+}
+
+func NewBitmapCache(root string) bitmapfilestore {
+	if err := os.MkdirAll(root, 0700); err != nil {
+		log.Println("unable to ensure bitmap cache root directory", err)
+	}
+
+	return bitmapfilestore{
+		root: root,
+	}
+}
+
+type bitmapfilestore struct {
+	root string
+}
+
+// Delete implements BitmapStore.
+func (t bitmapfilestore) Delete(id int160.T) error {
+	return os.Remove(t.path(id))
+}
+
+func (t bitmapfilestore) path(id int160.T) string {
+	return filepath.Join(t.root, fmt.Sprintf("%s.bitmap", id.String()))
+}
+
+func (t bitmapfilestore) Read(id int160.T) (*roaring.Bitmap, error) {
+	p := t.path(id)
+	src, err := os.Open(p)
+	if errors.Is(err, fs.ErrNotExist) {
+		return roaring.New(), nil
+	} else if err != nil {
+		return nil, errorsx.Wrapf(err, "unable to read bitmap from %s", p)
+	}
+	defer src.Close()
+
+	bm := roaring.New()
+
+	if _, err := bm.ReadFrom(src); err != nil {
+		return nil, errorsx.Wrapf(err, "unable to read bitmap from %s", p)
+	}
+
+	return bm, nil
+}
+
+func (t bitmapfilestore) Write(id int160.T, bitmap *roaring.Bitmap) error {
+	p := t.path(id)
+	dst, err := os.OpenFile(p, os.O_CREATE|os.O_WRONLY|os.O_SYNC, 0600)
+	if err != nil {
+		return errorsx.Wrapf(err, "unable to write bitmap to %s", p)
+	}
+	defer dst.Close()
+	if _, err := bitmap.WriteTo(dst); err != nil {
+		return errorsx.Wrapf(err, "unable to write bitmap to %s", p)
+	}
+	return nil
+}

--- a/client.go
+++ b/client.go
@@ -218,7 +218,7 @@ func NewClient(cfg *ClientConfig) (_ *Client, err error) {
 	cl := &Client{
 		config:   cfg,
 		closed:   make(chan struct{}),
-		torrents: torrentCache(cfg.defaultMetadata),
+		torrents: torrentCache(cfg.defaultMetadata, NewBitmapCache(cfg.defaultCacheDirectory)),
 		_mu:      &sync.RWMutex{},
 	}
 

--- a/client_internal_test.go
+++ b/client_internal_test.go
@@ -187,11 +187,9 @@ func DownloadCancelTest(t *testing.T, sb Binder, lb Binder, ps TestDownloadCance
 	// 	}()
 	// }
 
-	log.Println("DERP DERP 2")
 	_, err = DownloadInto(ctx, io.Discard, leecherGreeting, TuneClientPeer(seeder))
 	require.NoError(t, err)
 	require.Equal(t, false, leecherGreeting.(*torrent).chunks.ChunksMissing(0))
-	log.Println("DERP DERP 3")
 }
 
 // Ensure that it's an error for a peer to send an invalid have message.

--- a/config.go
+++ b/config.go
@@ -17,6 +17,7 @@ import (
 	"github.com/james-lawrence/torrent/dht/int160"
 	"github.com/james-lawrence/torrent/dht/krpc"
 	"github.com/james-lawrence/torrent/internal/netx"
+	"github.com/james-lawrence/torrent/internal/userx"
 	"github.com/james-lawrence/torrent/metainfo"
 	"github.com/james-lawrence/torrent/storage"
 	"github.com/james-lawrence/torrent/tracker"
@@ -31,8 +32,9 @@ const DefaultHTTPUserAgent = "Go-Torrent/1.0"
 
 // ClientConfig not safe to modify this after it's given to a Client.
 type ClientConfig struct {
-	defaultStorage  storage.ClientImpl
-	defaultMetadata MetadataStore
+	defaultCacheDirectory string
+	defaultStorage        storage.ClientImpl
+	defaultMetadata       MetadataStore
 
 	// defaultPortForwarding bool
 	dynamicip func(ctx context.Context, c *Client) (iter.Seq[netip.AddrPort], error)
@@ -361,9 +363,16 @@ func ClientConfigMaxOutstandingRequests(n int) ClientConfigOption {
 	}
 }
 
+func ClientConfigCacheDirectory(s string) ClientConfigOption {
+	return func(cc *ClientConfig) {
+		cc.defaultCacheDirectory = s
+	}
+}
+
 // NewDefaultClientConfig default client configuration.
 func NewDefaultClientConfig(mdstore MetadataStore, store storage.ClientImpl, options ...ClientConfigOption) *ClientConfig {
 	cc := &ClientConfig{
+		defaultCacheDirectory:          userx.DefaultCacheDirectory("torrents"),
 		defaultMetadata:                mdstore,
 		defaultStorage:                 store,
 		HTTPUserAgent:                  DefaultHTTPUserAgent,

--- a/connection.go
+++ b/connection.go
@@ -585,11 +585,12 @@ func (cn *connection) Have(piece uint64) (n int, err error) {
 }
 
 func (cn *connection) PostBitfield() (n int, err error) {
-	dup := cn.t.chunks.completed.Clone()
+	dup := cn.t.chunks.ReadableBitmap()
 	if dup.IsEmpty() {
 		dup = bitmapx.Zero(cn.t.chunks.pieces)
 	}
 
+	// cn.cfg.debug().Printf("c(%p) seed(%t) calculated bitfield: p(%d)/r(%d) - %v\n", cn, cn.t.seeding(), cn.t.chunks.pieces, dup.GetCardinality(), dup.ToArray())
 	n, err = cn.Post(pp.NewBitField(cn.t.chunks.pieces, dup))
 	if err != nil {
 		return n, err
@@ -833,7 +834,7 @@ func (cn *connection) onReadRequest(r request) error {
 		return nil
 	}
 
-	if !cn.t.havePiece(uint64(r.Index)) {
+	if !cn.t.chunks.ChunksReadable(uint64(r.Index)) {
 		// This isn't necessarily them screwing up. We can drop pieces
 		// from our storage, and can't communicate this to peers
 		// except by reconnecting.

--- a/global.go
+++ b/global.go
@@ -23,13 +23,5 @@ var (
 
 	completedHandshakeConnectionFlags = expvar.NewMap("completedHandshakeConnectionFlags")
 
-	receivedKeepalives    = expvar.NewInt("receivedKeepalives")
 	requestedChunkLengths = expvar.NewMap("requestedChunkLengths")
-
-	messageTypesReceived = expvar.NewMap("messageTypesReceived")
-
-	// Track the effectiveness of Torrent.connPieceInclinationPool.
-	pieceInclinationsReused = expvar.NewInt("pieceInclinationsReused")
-	pieceInclinationsNew    = expvar.NewInt("pieceInclinationsNew")
-	pieceInclinationsPut    = expvar.NewInt("pieceInclinationsPut")
 )

--- a/internal/envx/envx.go
+++ b/internal/envx/envx.go
@@ -1,0 +1,306 @@
+// Package envx provides utility functions for extracting information from environment variables
+package envx
+
+import (
+	"bufio"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/james-lawrence/torrent/internal/errorsx"
+	"github.com/james-lawrence/torrent/internal/slicesx"
+)
+
+// Int retrieve a integer flag from the environment, checks each key in order
+// first to parse successfully is returned.
+func Int[T int | int64](fallback T, keys ...string) T {
+	return envval(fallback, func(s string) (T, error) {
+		decoded, err := strconv.ParseInt(s, 10, 64)
+		return T(decoded), errorsx.Wrapf(err, "integer '%s' is invalid", s)
+	}, keys...)
+}
+
+// Boolean retrieve a boolean flag from the environment, checks each key in order
+// first to parse successfully is returned.
+func Boolean(fallback bool, keys ...string) bool {
+	return envval(fallback, func(s string) (bool, error) {
+		decoded, err := strconv.ParseBool(s)
+		return decoded, errorsx.Wrapf(err, "boolean '%s' is invalid", s)
+	}, keys...)
+}
+
+// Float64 retrieve a float64 flag from the environment, checks each key in order
+// first to parse successfully is returned.
+func Float64(fallback float64, keys ...string) float64 {
+	return envval(fallback, func(s string) (float64, error) {
+		decoded, err := strconv.ParseFloat(s, 64)
+		return decoded, errorsx.Wrapf(err, "float64 '%s' is invalid", s)
+	}, keys...)
+}
+
+// String retrieve a string value from the environment, checks each key in order
+// first string found is returned.
+func String(fallback string, keys ...string) string {
+	return envval(fallback, func(s string) (string, error) {
+		// we'll never receive an empty string because envval skips empty strings.
+		return s, nil
+	}, keys...)
+}
+
+// Strings retrieve a string array seperated by , value from the environment, checks each key in order
+// first string found is returned.
+func Strings(fallback []string, keys ...string) []string {
+	return envval(fallback, func(s string) ([]string, error) {
+		// we'll never receive an empty string because envval skips empty strings.
+		return strings.Split(s, ","), nil
+	}, keys...)
+}
+
+// Duration retrieves a time.Duration from the environment, checks each key in order
+// first successful parse to a duration is returned.
+func Duration(fallback time.Duration, keys ...string) time.Duration {
+	return envval(fallback, func(s string) (time.Duration, error) {
+		decoded, err := time.ParseDuration(s)
+		return decoded, errorsx.Wrapf(err, "time.Duration '%s' is invalid", s)
+	}, keys...)
+}
+
+// BytesFile treats the value in the provided environment keys as a file path.
+func BytesFile(fallback []byte, keys ...string) []byte {
+	return envval(fallback, func(s string) ([]byte, error) {
+		decoded, err := os.ReadFile(s)
+		return decoded, errorsx.Wrapf(err, "file path '%s' was inaccessible", s)
+	}, keys...)
+}
+
+// BytesHex read value as a hex encoded string.
+func BytesHex(fallback []byte, keys ...string) []byte {
+	return envval(fallback, func(s string) ([]byte, error) {
+		decoded, err := hex.DecodeString(s)
+		return decoded, errorsx.Wrapf(err, "invalid hex encoded data '%s'", s)
+	}, keys...)
+}
+
+// BytesB64 read value as a base64 encoded string
+func BytesB64(fallback []byte, keys ...string) []byte {
+	enc := base64.RawStdEncoding.WithPadding('=')
+	return envval(fallback, func(s string) ([]byte, error) {
+		decoded, err := enc.DecodeString(s)
+		return decoded, errorsx.Wrapf(err, "invalid base64 encoded data '%s'", s)
+	}, keys...)
+}
+
+func URL(fallback string, keys ...string) *url.URL {
+	var (
+		err    error
+		parsed *url.URL
+	)
+
+	if parsed, err = url.Parse(fallback); err != nil {
+		panic(errorsx.Wrap(err, "must provide a valid fallback url"))
+	}
+
+	return envval(parsed, func(s string) (*url.URL, error) {
+		decoded, err := url.Parse(s)
+		return decoded, errorsx.WithStack(err)
+	}, keys...)
+}
+
+func envval[T any](fallback T, parse func(string) (T, error), keys ...string) T {
+	for _, k := range keys {
+		s := strings.TrimSpace(os.Getenv(k))
+		if s == "" {
+			continue
+		}
+
+		decoded, err := parse(s)
+		if err != nil {
+			log.Printf("%s stored an invalid value %v\n", k, err)
+			continue
+		}
+
+		return decoded
+	}
+
+	return fallback
+}
+
+func Build() *Builder {
+	return &Builder{}
+}
+
+type Builder struct {
+	environ []string
+	failed  error
+}
+
+func (t Builder) CopyTo(w io.Writer) error {
+	if t.failed != nil {
+		return t.failed
+	}
+
+	for _, e := range t.environ {
+		if _, err := fmt.Fprintf(w, "%s\n", e); err != nil {
+			return errorsx.Wrapf(err, "unable to write environment variable: %s", e)
+		}
+	}
+
+	return nil
+}
+
+func (t Builder) Environ() ([]string, error) {
+	return t.environ, t.failed
+}
+
+// set a single variable to a value.
+func (t *Builder) Var(k, v string) *Builder {
+	if encoded := Format(k, v); encoded != "" {
+		t.environ = append(t.environ, fmt.Sprintf("%s=%s", k, v))
+	}
+	return t
+}
+
+// extract environment variables from a file on disk.
+// missing files are treated as noops.
+func (t *Builder) FromPath(n string) *Builder {
+	tmp, err := FromPath(n)
+	t.environ = append(t.environ, tmp...)
+	t.failed = errors.Join(t.failed, err)
+	return t
+}
+
+// extract environment variables from an io.Reader.
+// the format is the standard .env file formats.
+func (t *Builder) FromReader(r io.Reader) *Builder {
+	tmp, err := FromReader(r)
+	t.environ = append(t.environ, tmp...)
+	t.failed = errors.Join(t.failed, err)
+	return t
+}
+
+func (t *Builder) FromEnviron(environ ...string) *Builder {
+	t.environ = append(t.environ, environ...)
+	return t
+}
+
+// extract the key/value pairs from the os.Environ.
+// empty keys are passed as k=
+func (t *Builder) FromEnv(keys ...string) *Builder {
+	vars := make([]string, 0, len(keys))
+
+	for _, k := range keys {
+		if v, ok := os.LookupEnv(k); ok {
+			vars = append(vars, Format(k, v, FormatOptionTransforms(allowAll)))
+		}
+	}
+
+	t.environ = append(t.environ, vars...)
+
+	return t
+}
+
+type formatoption func(*formatopts)
+type formatopts struct {
+	transformer func(string) string // transforms that result in empty strings are ignored.
+}
+
+func allowAll(s string) string {
+	return s
+}
+
+func ignoreEmptyVariables(s string) string {
+	if strings.HasSuffix(s, "=") {
+		return ""
+	}
+
+	return s
+}
+
+func FormatOptionTransforms(transforms ...func(string) string) formatoption {
+	combined := func(s string) string {
+		for _, trans := range transforms {
+			s = trans(s)
+		}
+
+		return s
+	}
+
+	return func(f *formatopts) {
+		f.transformer = combined
+	}
+}
+
+// set many keys to the same value.
+func Vars(v string, keys ...string) (environ []string) {
+	environ = make([]string, 0, len(keys))
+	for _, k := range keys {
+		environ = append(environ, Format(k, v))
+	}
+
+	return environ
+}
+
+// format a environment variable in k=v.
+//
+// - doesn't currently escape values. it may in the future.
+//
+// - if the key or value are an empty string it'll return an empty string. it will log if debugging is enabled.
+func Format(k, v string, options ...func(*formatopts)) string {
+	opts := slicesx.Reduce(&formatopts{
+		transformer: ignoreEmptyVariables,
+	}, options...)
+	evar := strings.TrimSpace(opts.transformer(fmt.Sprintf("%s=%s", k, v)))
+	if evar == "" {
+		log.Println("ignoring variable", k, "empty")
+	}
+
+	return fmt.Sprintf("%s=%s", k, v)
+}
+
+// returns the os.Environ or an empty slice if b is false.
+func Dirty(b bool) []string {
+	if b {
+		return os.Environ()
+	}
+
+	return nil
+}
+
+func Debug(envs ...string) {
+	errorsx.Log(log.Output(2, fmt.Sprintln("DEBUG ENVIRONMENT INITIATED")))
+	defer func() { errorsx.Log(log.Output(3, "DEBUG ENVIRONMENT COMPLETED")) }()
+	for _, e := range envs {
+		errorsx.Log(log.Output(2, fmt.Sprintln(e)))
+	}
+}
+
+func FromReader(r io.Reader) (environ []string, err error) {
+	scanner := bufio.NewScanner(r)
+
+	for scanner.Scan() {
+		environ = append(environ, scanner.Text())
+	}
+
+	return environ, nil
+}
+
+func FromPath(n string) (environ []string, err error) {
+	env, err := os.Open(n)
+	if os.IsNotExist(err) {
+		return environ, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer env.Close()
+
+	return FromReader(env)
+}

--- a/internal/userx/userx.go
+++ b/internal/userx/userx.go
@@ -1,0 +1,128 @@
+package userx
+
+import (
+	"log"
+	"os"
+	"os/user"
+	"path/filepath"
+
+	"github.com/james-lawrence/torrent/internal/envx"
+)
+
+func Root() user.User {
+	return user.User{
+		Gid:     "0",
+		Uid:     "0",
+		HomeDir: "/root",
+	}
+}
+
+func Zero() user.User {
+	return user.User{}
+}
+
+// CurrentUserOrDefault returns the current user or the default configured user.
+func CurrentUserOrDefault(d user.User) (result *user.User) {
+	var (
+		err error
+	)
+
+	if result, err = user.Current(); err != nil {
+		log.Println("failed to retrieve current user, using default", err)
+		tmp := d
+		return &tmp
+	}
+
+	return result
+}
+
+// DefaultConfigDir returns the user config directory.
+func DefaultConfigDir(rel ...string) string {
+	user := CurrentUserOrDefault(Root())
+	defaultdir := filepath.Join(user.HomeDir, ".config")
+	return filepath.Join(envx.String(defaultdir, "XDG_CONFIG_HOME"), filepath.Join(rel...))
+}
+
+// DefaultDirLocation looks for a directory one of the default directory locations.
+func DefaultDirLocation(rel string) string {
+	user := CurrentUserOrDefault(Root())
+
+	env := filepath.Join(os.Getenv("XDG_CONFIG_HOME"))
+	home := filepath.Join(user.HomeDir, ".config")
+	system := filepath.Join("/etc")
+
+	return DefaultDirectory(rel, env, home, system)
+}
+
+// DefaultCacheDirectory cache directory for storing data.
+func DefaultCacheDirectory(rel ...string) string {
+	user := CurrentUserOrDefault(Root())
+	if user.Uid == Root().Uid {
+		return envx.String(filepath.Join("/", "var", "cache"), "CACHE_DIRECTORY")
+	}
+
+	defaultdir := filepath.Join(user.HomeDir, ".cache")
+	return filepath.Join(envx.String(defaultdir, "CACHE_DIRECTORY", "XDG_CACHE_HOME"), filepath.Join(rel...))
+}
+
+func DefaultDataDirectory(rel ...string) string {
+	user := CurrentUserOrDefault(Root())
+	defaultdir := filepath.Join(user.HomeDir, ".local", "share")
+	return filepath.Join(envx.String(defaultdir, "XDG_DATA_HOME"), filepath.Join(rel...))
+}
+
+// DefaultDownloadDirectory returns the user config directory.
+func DefaultDownloadDirectory(rel ...string) string {
+	user := CurrentUserOrDefault(Root())
+	auto := filepath.Join(user.HomeDir, "Downloads")
+	return filepath.Join(envx.String(auto, "XDG_DOWNLOAD_DIR"), filepath.Join(rel...))
+}
+
+// DefaultRuntimeDirectory runtime directory for storing data.
+func DefaultRuntimeDirectory(rel ...string) string {
+	user := CurrentUserOrDefault(Root())
+
+	if user.Uid == Root().Uid {
+		return envx.String(filepath.Join("/", "run"), "RUNTIME_DIRECTORY", "XDG_RUNTIME_DIR")
+	}
+
+	defaultdir := filepath.Join("/", "run", "user", user.Uid)
+	return filepath.Join(envx.String(defaultdir, "RUNTIME_DIRECTORY", "XDG_RUNTIME_DIR"), filepath.Join(rel...))
+}
+
+// return a path relative to the home directory.
+func HomeDirectoryRel(rel ...string) (path string, err error) {
+	if path, err = os.UserHomeDir(); err != nil {
+		return "", err
+	}
+
+	return filepath.Join(path, filepath.Join(rel...)), nil
+}
+
+// DefaultDirectory finds the first directory root that exists and then returns
+// that root directory joined with the relative path provided.
+func DefaultDirectory(rel string, roots ...string) (path string) {
+	for _, root := range roots {
+		path = filepath.Join(root, rel)
+		if _, err := os.Stat(root); err == nil {
+			return path
+		}
+	}
+
+	return path
+}
+
+// HomeDirectoryOrDefault loads the user home directory or falls back to the provided
+// path when an error occurs.
+func HomeDirectoryOrDefault(fallback string) (dir string) {
+	var (
+		err error
+	)
+
+	if dir, err = os.UserHomeDir(); err != nil {
+		log.Println("unable to get user home directory", err)
+		return fallback
+	}
+
+	return dir
+}

--- a/internal/x/bitmapx/bitmapx.go
+++ b/internal/x/bitmapx/bitmapx.go
@@ -1,6 +1,8 @@
 package bitmapx
 
 import (
+	"math/rand/v2"
+
 	"github.com/RoaringBitmap/roaring/v2"
 )
 
@@ -21,7 +23,7 @@ func Lazy(m *roaring.Bitmap) *roaring.Bitmap {
 		return m
 	}
 
-	return roaring.NewBitmap()
+	return roaring.New()
 }
 
 // Contains returns iff all the bits are set within the bitmap
@@ -58,4 +60,16 @@ func Zero(max uint64) *roaring.Bitmap {
 
 func Fill(max uint64) *roaring.Bitmap {
 	return Range(0, max)
+}
+
+func Random(max uint32, bits int, src rand.Source) *roaring.Bitmap {
+	r := rand.New(src)
+	m := roaring.New()
+
+	for range bits {
+		v := r.Uint32N(max)
+		m.Add(v)
+	}
+
+	return m
 }

--- a/torrent.cache.go
+++ b/torrent.cache.go
@@ -1,0 +1,136 @@
+package torrent
+
+import (
+	"sync"
+
+	"github.com/james-lawrence/torrent/dht/int160"
+)
+
+func torrentCache(s MetadataStore, b BitmapStore) *memoryseeding {
+	return &memoryseeding{
+		_mu:           &sync.RWMutex{},
+		MetadataStore: s,
+		bm:            b,
+		torrents:      make(map[int160.T]*torrent, 128),
+	}
+}
+
+type memoryseeding struct {
+	MetadataStore
+	bm       BitmapStore
+	_mu      *sync.RWMutex
+	torrents map[int160.T]*torrent
+}
+
+func (t *memoryseeding) Close() error {
+	t._mu.Lock()
+	defer t._mu.Unlock()
+
+	for _, c := range t.torrents {
+		if err := c.close(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// clear torrent from memory
+func (t *memoryseeding) Drop(id int160.T) error {
+	t._mu.RLock()
+	c, ok := t.torrents[id]
+	t._mu.RUnlock()
+
+	if !ok {
+		return nil
+	}
+
+	t._mu.Lock()
+	delete(t.torrents, id)
+	t._mu.Unlock()
+
+	// only record if the info is there.
+	if c.haveInfo() {
+		if err := t.bm.Write(id, c.chunks.missing.Clone()); err != nil {
+			return err
+		}
+	}
+
+	return c.close()
+}
+
+func (t *memoryseeding) Insert(cl *Client, md Metadata) (*torrent, error) {
+	id := int160.FromBytes(md.ID.Bytes())
+	t._mu.RLock()
+	x, ok := t.torrents[id]
+	t._mu.RUnlock()
+
+	if ok {
+		return x, nil
+	}
+
+	// only record if the info is there.
+	if len(md.InfoBytes) > 0 {
+		if err := t.MetadataStore.Write(md); err != nil {
+			return nil, err
+		}
+	}
+
+	dlt := newTorrent(cl, md)
+	t._mu.Lock()
+	t.torrents[id] = dlt
+	t._mu.Unlock()
+
+	if len(md.InfoBytes) > 0 {
+		if err := t.bm.Write(id, dlt.chunks.missing.Clone()); err != nil {
+			return nil, err
+		}
+	}
+
+	return dlt, nil
+}
+
+func (t *memoryseeding) Load(cl *Client, id int160.T) (_ *torrent, cached bool, _ error) {
+	t._mu.RLock()
+	x, ok := t.torrents[id]
+	t._mu.RUnlock()
+
+	if ok {
+		return x, true, nil
+	}
+
+	t._mu.Lock()
+	defer t._mu.Unlock()
+
+	if x, ok := t.torrents[id]; ok {
+		return x, true, nil
+	}
+
+	md, err := t.MetadataStore.Read(id)
+	if err != nil {
+		return nil, false, err
+	}
+
+	missing, err := t.bm.Read(id)
+	if err != nil {
+		return nil, false, err
+	}
+
+	dlt := newTorrent(cl, md)
+	dlt.chunks.InitFromMissing(missing)
+
+	t.torrents[id] = dlt
+
+	return dlt, false, nil
+}
+
+func (t *memoryseeding) Metadata(id int160.T) (md Metadata, err error) {
+	t._mu.Lock()
+	defer t._mu.Unlock()
+
+	if x, ok := t.torrents[id]; ok {
+		return x.md, nil
+	}
+
+	return t.MetadataStore.Read(id)
+}

--- a/torrent.go
+++ b/torrent.go
@@ -917,10 +917,6 @@ func (t *torrent) pieceLength(piece uint64) pp.Integer {
 	return pp.Integer(t.info.PieceLength)
 }
 
-func (t *torrent) havePiece(index uint64) bool {
-	return t.chunks.ChunksComplete(index)
-}
-
 // The worst connection is one that hasn't been sent, or sent anything useful
 // for the longest. A bad connection is one that usually sends us unwanted
 // pieces, or has been in worser half of the established connections for more
@@ -1476,14 +1472,14 @@ func (t *torrent) String() string {
 }
 
 func (t *torrent) ping(addr net.UDPAddr) {
-	// t.cln.eachDhtServer(func(s *dht.Server) {
-	// 	go func() {
-	// 		ret := dht.Ping3S(context.Background(), s, dht.NewAddr(&addr), s.ID())
-	// 		if errorsx.Ignore(ret.Err, context.DeadlineExceeded) != nil {
-	// 			log.Println("failed to ping address", ret.Err)
-	// 		}
-	// 	}()
-	// })
+	t.cln.eachDhtServer(func(s *dht.Server) {
+		go func() {
+			ret := dht.Ping3S(context.Background(), s, dht.NewAddr(&addr), s.ID())
+			if errorsx.Ignore(ret.Err, context.DeadlineExceeded) != nil {
+				log.Println("failed to ping address", ret.Err)
+			}
+		}()
+	})
 }
 
 // Process incoming ut_metadata message.


### PR DESCRIPTION
uses the missing chunk bitmap to track progress. this is sufficient data.

if the progress gets lost (removed from disk) torrents start out in an unverified state and accessing the data will force them to revalidate any data they send or try to access.