### PR TITLE
perf(bitfield): bitfield unmarshaling and extended payload reading

### DIFF
--- a/bencode/decode.go
+++ b/bencode/decode.go
@@ -336,72 +336,68 @@ func getDictField(dict reflect.Type, key reflect.Value) (_ dictField, err error)
 }
 
 var (
-	structFieldsMu sync.Mutex
-	structFields   = map[reflect.Type]map[string]dictField{}
+	structFields   sync.Map // map[reflect.Type]map[string]dictField
 )
 
 func parseStructFields(struct_ reflect.Type, each func(key string, df dictField)) {
-	for _i, n := 0, struct_.NumField(); _i < n; _i++ {
-		i := _i
-		f := struct_.Field(i)
-		if f.Anonymous {
-			t := f.Type
-			if t.Kind() == reflect.Ptr {
-				t = t.Elem()
-			}
-			parseStructFields(t, func(key string, df dictField) {
-				innerGet := df.Get
-				df.Get = func(value reflect.Value) func(reflect.Value) {
-					anonPtr := value.Field(i)
-					if anonPtr.Kind() == reflect.Ptr && anonPtr.IsNil() {
-						anonPtr.Set(reflect.New(f.Type.Elem()))
-						anonPtr = anonPtr.Elem()
-					}
-					return innerGet(anonPtr)
-				}
-				each(key, df)
-			})
-			continue
-		}
-		tagStr := f.Tag.Get("bencode")
-		if tagStr == "-" {
-			continue
-		}
-		tag := parseTag(tagStr)
-		key := tag.Key()
-		if key == "" {
-			key = f.Name
-		}
-		each(key, dictField{f.Type, func(value reflect.Value) func(reflect.Value) {
-			return value.Field(i).Set
-		}, tag})
-	}
-}
-
-func saveStructFields(struct_ reflect.Type) {
-	m := make(map[string]dictField)
-	parseStructFields(struct_, func(key string, sf dictField) {
-		m[key] = sf
-	})
-	structFields[struct_] = m
+    for _i, n := 0, struct_.NumField(); _i < n; _i++ {
+        i := _i
+        f := struct_.Field(i)
+        if f.Anonymous {
+            t := f.Type
+            if t.Kind() == reflect.Ptr {
+                t = t.Elem()
+            }
+            parseStructFields(t, func(key string, df dictField) {
+                innerGet := df.Get
+                df.Get = func(value reflect.Value) func(reflect.Value) {
+                    anonPtr := value.Field(i)
+                    if anonPtr.Kind() == reflect.Ptr && anonPtr.IsNil() {
+                        anonPtr.Set(reflect.New(f.Type.Elem()))
+                        anonPtr = anonPtr.Elem()
+                    }
+                    return innerGet(anonPtr)
+                }
+                each(key, df)
+            })
+            continue
+        }
+        tagStr := f.Tag.Get("bencode")
+        if tagStr == "-" {
+            continue
+        }
+        tag := parseTag(tagStr)
+        key := tag.Key()
+        if key == "" {
+            key = f.Name
+        }
+        each(key, dictField{f.Type, func(value reflect.Value) func(reflect.Value) {
+            return value.Field(i).Set
+        }, tag})
+    }
 }
 
 func getStructFieldForKey(struct_ reflect.Type, key string) (f dictField) {
-	structFieldsMu.Lock()
-	if _, ok := structFields[struct_]; !ok {
-		saveStructFields(struct_)
-	}
-	f, ok := structFields[struct_][key]
-	structFieldsMu.Unlock()
-	if !ok {
-		var discard interface{}
-		return dictField{
-			Type: reflect.TypeOf(discard),
-			Get:  func(reflect.Value) func(reflect.Value) { return func(reflect.Value) {} },
-			Tags: nil,
-		}
-	}
-	return
+    mi, ok := structFields.Load(struct_)
+    if !ok {
+        m := make(map[string]dictField)
+        parseStructFields(struct_, func(key string, df dictField) {
+            m[key] = df
+        })
+        loaded, _ := structFields.LoadOrStore(struct_, m)
+        mi = loaded
+    }
+    m := mi.(map[string]dictField)
+    f, ok = m[key]
+    if !ok {
+        var discard interface{}
+        return dictField{
+            Type: reflect.TypeOf(discard),
+            Get:  func(reflect.Value) func(reflect.Value) { return func(reflect.Value) {} },
+            Tags: nil,
+        }
+    }
+    return
 }
 
 var structKeyType = reflect.TypeFor[string]()

--- a/bencode/decode_test.go
+++ b/bencode/decode_test.go
@@ -290,3 +290,16 @@ func TestJsonDecoderBehaviour(t *testing.T) {
 	test("{}", 1, io.EOF)
 	test("{} {", 1, io.ErrUnexpectedEOF)
 }
+func BenchmarkGetStructFieldForKey(b *testing.B) {
+    type TestStruct struct {
+        Field1 string `bencode:"field1"`
+        Field2 int    `bencode:"field2"`
+    }
+    testType := reflect.TypeOf(TestStruct{})
+    b.ResetTimer()
+    b.RunParallel(func(pb *testing.PB) {
+        for pb.Next() {
+            getStructFieldForKey(testType, "field1")
+        }
+    })
+}

--- a/bencode/encode_test.go
+++ b/bencode/encode_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"math/big"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -88,4 +89,17 @@ func TestRandomEncode(t *testing.T) {
 		assert.NoError(t, err, "%s", test)
 		assert.EqualValues(t, test.expected, string(data))
 	}
+}
+func BenchmarkGetEncodeFields(b *testing.B) {
+    type TestStruct struct {
+        Field1 string `bencode:"field1"`
+        Field2 int    `bencode:"field2"`
+    }
+    testType := reflect.TypeOf(TestStruct{})
+    b.ResetTimer()
+    b.RunParallel(func(pb *testing.PB) {
+        for pb.Next() {
+            getEncodeFields(testType)
+        }
+    })
 }

--- a/btprotocol/decoder.go
+++ b/btprotocol/decoder.go
@@ -102,7 +102,9 @@ func (d *Decoder) Decode(msg *Message) (err error) {
 			return err
 		}
 		msg.ExtendedID = ExtensionNumber(b)
-		msg.ExtendedPayload, err = io.ReadAll(r)
+		payloadLen := int(r.N)
+		msg.ExtendedPayload = make([]byte, payloadLen)
+		_, err = io.ReadFull(r, msg.ExtendedPayload)
 		return err
 	case Port:
 		return binary.Read(r, binary.BigEndian, &msg.Port)
@@ -122,10 +124,14 @@ func readByte(r io.Reader) (b byte, err error) {
 }
 
 func unmarshalBitfield(b []byte) (bf []bool) {
-	for _, c := range b {
-		for i := 7; i >= 0; i-- {
-			bf = append(bf, (c>>uint(i))&1 == 1)
-		}
-	}
-	return
+    length := len(b) * 8
+    bf = make([]bool, length)
+    idx := 0
+    for _, c := range b {
+        for i := 7; i >= 0; i-- {
+            bf[idx] = (c >> uint(i)) & 1 == 1
+            idx++
+        }
+    }
+    return
 }

--- a/btprotocol/decoder_test.go
+++ b/btprotocol/decoder_test.go
@@ -2,6 +2,7 @@ package btprotocol
 
 import (
 	"bufio"
+	"encoding/binary"
 	"io"
 	"sync"
 	"testing"
@@ -89,4 +90,70 @@ func TestDecodeOverlongPiece(t *testing.T) {
 	}
 	var m Message
 	require.Error(t, d.Decode(&m))
+}
+func BenchmarkDecodeBitfield(b *testing.B) {
+    r, w := io.Pipe()
+    const bitfieldLen = 128 * 1024
+    bitfieldData := make([]byte, bitfieldLen)
+    msgLen := uint32(1 + bitfieldLen)
+    var lenBuf [4]byte
+    binary.BigEndian.PutUint32(lenBuf[:], msgLen)
+    data := append(lenBuf[:], byte(Bitfield))
+    data = append(data, bitfieldData...)
+    b.SetBytes(int64(len(data)))
+    b.ReportAllocs()
+    defer r.Close()
+    go func() {
+        defer w.Close()
+        for {
+            n, err := w.Write(data)
+            if err == io.ErrClosedPipe {
+                return
+            }
+            require.NoError(b, err)
+            require.Equal(b, len(data), n)
+        }
+    }()
+    d := Decoder{
+        R:         bufio.NewReader(r),
+        MaxLength: 1 << 18,
+    }
+    for i := 0; i < b.N; i++ {
+        var msg Message
+        require.NoError(b, d.Decode(&msg))
+    }
+}
+
+func BenchmarkDecodeExtended(b *testing.B) {
+    r, w := io.Pipe()
+    const payloadLen = 128 * 1024
+    payloadData := make([]byte, payloadLen)
+    msgLen := uint32(1 + 1 + payloadLen)
+    var lenBuf [4]byte
+    binary.BigEndian.PutUint32(lenBuf[:], msgLen)
+    data := append(lenBuf[:], byte(Extended))
+    data = append(data, byte(0))
+    data = append(data, payloadData...)
+    b.SetBytes(int64(len(data)))
+    b.ReportAllocs()
+    defer r.Close()
+    go func() {
+        defer w.Close()
+        for {
+            n, err := w.Write(data)
+            if err == io.ErrClosedPipe {
+                return
+            }
+            require.NoError(b, err)
+            require.Equal(b, len(data), n)
+        }
+    }()
+    d := Decoder{
+        R:         bufio.NewReader(r),
+        MaxLength: 1 << 18,
+    }
+    for i := 0; i < b.N; i++ {
+        var msg Message
+        require.NoError(b, d.Decode(&msg))
+    }
 }


### PR DESCRIPTION
Preallocated slices in unmarshalBitfield and switched io.ReadAll to io.ReadFull in Decode for Extended messages. Benchmark below:

**Before**
```
goos: darwin
goarch: arm64
pkg: github.com/james-lawrence/torrent/btprotocol
cpu: Apple M1 Pro
BenchmarkDecodeBitfield-10          1449        877659 ns/op     149.35 MB/s     5373023 B/op         43 allocs/op
PASS
ok      github.com/james-lawrence/torrent/btprotocol    2.595s

goos: darwin
goarch: arm64
pkg: github.com/james-lawrence/torrent/btprotocol
cpu: Apple M1 Pro
BenchmarkDecodeExtended-10         18334         67085 ns/op    1953.91 MB/s      686423 B/op         25 allocs/op
PASS
ok      github.com/james-lawrence/torrent/btprotocol    2.115s
```

**After**
```
goos: darwin
goarch: arm64
pkg: github.com/james-lawrence/torrent/btprotocol
cpu: Apple M1 Pro
BenchmarkDecodeBitfield-10          1567        792870 ns/op     165.32 MB/s     1179896 B/op          7 allocs/op
PASS
ok      github.com/james-lawrence/torrent/btprotocol    2.532s

goos: darwin
goarch: arm64
pkg: github.com/james-lawrence/torrent/btprotocol
cpu: Apple M1 Pro
BenchmarkDecodeExtended-10         95728         11966 ns/op    10954.15 MB/s     131129 B/op          7 allocs/op
PASS
ok      github.com/james-lawrence/torrent/btprotocol    1.493s

```