### PR TITLE
perf(bencode): use sync.Map for struct field caching to reduce contention

### DIFF
--- a/bencode/decode.go
+++ b/bencode/decode.go
@@ -336,72 +336,68 @@ func getDictField(dict reflect.Type, key reflect.Value) (_ dictField, err error)
 }
 
 var (
-	structFieldsMu sync.Mutex
-	structFields   = map[reflect.Type]map[string]dictField{}
+	structFields   sync.Map // map[reflect.Type]map[string]dictField
 )
 
 func parseStructFields(struct_ reflect.Type, each func(key string, df dictField)) {
-	for _i, n := 0, struct_.NumField(); _i < n; _i++ {
-		i := _i
-		f := struct_.Field(i)
-		if f.Anonymous {
-			t := f.Type
-			if t.Kind() == reflect.Ptr {
-				t = t.Elem()
-			}
-			parseStructFields(t, func(key string, df dictField) {
-				innerGet := df.Get
-				df.Get = func(value reflect.Value) func(reflect.Value) {
-					anonPtr := value.Field(i)
-					if anonPtr.Kind() == reflect.Ptr && anonPtr.IsNil() {
-						anonPtr.Set(reflect.New(f.Type.Elem()))
-						anonPtr = anonPtr.Elem()
-					}
-					return innerGet(anonPtr)
-				}
-				each(key, df)
-			})
-			continue
-		}
-		tagStr := f.Tag.Get("bencode")
-		if tagStr == "-" {
-			continue
-		}
-		tag := parseTag(tagStr)
-		key := tag.Key()
-		if key == "" {
-			key = f.Name
-		}
-		each(key, dictField{f.Type, func(value reflect.Value) func(reflect.Value) {
-			return value.Field(i).Set
-		}, tag})
-	}
-}
-
-func saveStructFields(struct_ reflect.Type) {
-	m := make(map[string]dictField)
-	parseStructFields(struct_, func(key string, sf dictField) {
-		m[key] = sf
-	})
-	structFields[struct_] = m
+    for _i, n := 0, struct_.NumField(); _i < n; _i++ {
+        i := _i
+        f := struct_.Field(i)
+        if f.Anonymous {
+            t := f.Type
+            if t.Kind() == reflect.Ptr {
+                t = t.Elem()
+            }
+            parseStructFields(t, func(key string, df dictField) {
+                innerGet := df.Get
+                df.Get = func(value reflect.Value) func(reflect.Value) {
+                    anonPtr := value.Field(i)
+                    if anonPtr.Kind() == reflect.Ptr && anonPtr.IsNil() {
+                        anonPtr.Set(reflect.New(f.Type.Elem()))
+                        anonPtr = anonPtr.Elem()
+                    }
+                    return innerGet(anonPtr)
+                }
+                each(key, df)
+            })
+            continue
+        }
+        tagStr := f.Tag.Get("bencode")
+        if tagStr == "-" {
+            continue
+        }
+        tag := parseTag(tagStr)
+        key := tag.Key()
+        if key == "" {
+            key = f.Name
+        }
+        each(key, dictField{f.Type, func(value reflect.Value) func(reflect.Value) {
+            return value.Field(i).Set
+        }, tag})
+    }
 }
 
 func getStructFieldForKey(struct_ reflect.Type, key string) (f dictField) {
-	structFieldsMu.Lock()
-	if _, ok := structFields[struct_]; !ok {
-		saveStructFields(struct_)
-	}
-	f, ok := structFields[struct_][key]
-	structFieldsMu.Unlock()
-	if !ok {
-		var discard interface{}
-		return dictField{
-			Type: reflect.TypeOf(discard),
-			Get:  func(reflect.Value) func(reflect.Value) { return func(reflect.Value) {} },
-			Tags: nil,
-		}
-	}
-	return
+    mi, ok := structFields.Load(struct_)
+    if !ok {
+        m := make(map[string]dictField)
+        parseStructFields(struct_, func(key string, df dictField) {
+            m[key] = df
+        })
+        loaded, _ := structFields.LoadOrStore(struct_, m)
+        mi = loaded
+    }
+    m := mi.(map[string]dictField)
+    f, ok = m[key]
+    if !ok {
+        var discard interface{}
+        return dictField{
+            Type: reflect.TypeOf(discard),
+            Get:  func(reflect.Value) func(reflect.Value) { return func(reflect.Value) {} },
+            Tags: nil,
+        }
+    }
+    return
 }
 
 var structKeyType = reflect.TypeFor[string]()

--- a/bencode/decode_test.go
+++ b/bencode/decode_test.go
@@ -290,3 +290,16 @@ func TestJsonDecoderBehaviour(t *testing.T) {
 	test("{}", 1, io.EOF)
 	test("{} {", 1, io.ErrUnexpectedEOF)
 }
+func BenchmarkGetStructFieldForKey(b *testing.B) {
+    type TestStruct struct {
+        Field1 string `bencode:"field1"`
+        Field2 int    `bencode:"field2"`
+    }
+    testType := reflect.TypeOf(TestStruct{})
+    b.ResetTimer()
+    b.RunParallel(func(pb *testing.PB) {
+        for pb.Next() {
+            getStructFieldForKey(testType, "field1")
+        }
+    })
+}

--- a/bencode/decode_test.go
+++ b/bencode/decode_test.go
@@ -290,16 +290,17 @@ func TestJsonDecoderBehaviour(t *testing.T) {
 	test("{}", 1, io.EOF)
 	test("{} {", 1, io.ErrUnexpectedEOF)
 }
+
 func BenchmarkGetStructFieldForKey(b *testing.B) {
-    type TestStruct struct {
-        Field1 string `bencode:"field1"`
-        Field2 int    `bencode:"field2"`
-    }
-    testType := reflect.TypeOf(TestStruct{})
-    b.ResetTimer()
-    b.RunParallel(func(pb *testing.PB) {
-        for pb.Next() {
-            getStructFieldForKey(testType, "field1")
-        }
-    })
+	type TestStruct struct {
+		Field1 string `bencode:"field1"`
+		Field2 int    `bencode:"field2"`
+	}
+	testType := reflect.TypeOf(TestStruct{})
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			getStructFieldForKey(testType, "field1")
+		}
+	})
 }

--- a/bencode/encode.go
+++ b/bencode/encode.go
@@ -242,63 +242,63 @@ var (
 )
 
 func getEncodeFields(t reflect.Type) []encodeField {
-    fsi, ok := encodeFieldsCache.Load(t)
-    if ok {
-        return fsi.([]encodeField)
-    }
-    fs := makeEncodeFields(t)
-    loaded, _ := encodeFieldsCache.LoadOrStore(t, fs)
-    return loaded.([]encodeField)
+	fsi, ok := encodeFieldsCache.Load(t)
+	if ok {
+		return fsi.([]encodeField)
+	}
+	fs := makeEncodeFields(t)
+	loaded, _ := encodeFieldsCache.LoadOrStore(t, fs)
+	return loaded.([]encodeField)
 }
 
 func makeEncodeFields(t reflect.Type) (fs []encodeField) {
-    for _i, n := 0, t.NumField(); _i < n; _i++ {
-        i := _i
-        f := t.Field(i)
-        if f.PkgPath != "" {
-            continue
-        }
-        if f.Anonymous {
-            t := f.Type
-            if t.Kind() == reflect.Ptr {
-                t = t.Elem()
-            }
-            anonEFs := makeEncodeFields(t)
-            for aefi := range anonEFs {
-                anonEF := anonEFs[aefi]
-                bottomField := anonEF
-                bottomField.i = func(v reflect.Value) reflect.Value {
-                    v = v.Field(i)
-                    if v.Kind() == reflect.Ptr {
-                        if v.IsNil() {
-                            // This will skip serializing this value.
-                            return reflect.Value{}
-                        }
-                        v = v.Elem()
-                    }
-                    return anonEF.i(v)
-                }
-                fs = append(fs, bottomField)
-            }
-            continue
-        }
-        var ef encodeField
-        ef.i = func(v reflect.Value) reflect.Value {
-            return v.Field(i)
-        }
-        ef.tag = f.Name
+	for _i, n := 0, t.NumField(); _i < n; _i++ {
+		i := _i
+		f := t.Field(i)
+		if f.PkgPath != "" {
+			continue
+		}
+		if f.Anonymous {
+			t := f.Type
+			if t.Kind() == reflect.Ptr {
+				t = t.Elem()
+			}
+			anonEFs := makeEncodeFields(t)
+			for aefi := range anonEFs {
+				anonEF := anonEFs[aefi]
+				bottomField := anonEF
+				bottomField.i = func(v reflect.Value) reflect.Value {
+					v = v.Field(i)
+					if v.Kind() == reflect.Ptr {
+						if v.IsNil() {
+							// This will skip serializing this value.
+							return reflect.Value{}
+						}
+						v = v.Elem()
+					}
+					return anonEF.i(v)
+				}
+				fs = append(fs, bottomField)
+			}
+			continue
+		}
+		var ef encodeField
+		ef.i = func(v reflect.Value) reflect.Value {
+			return v.Field(i)
+		}
+		ef.tag = f.Name
 
-        tv := getTag(f.Tag)
-        if tv.Ignore() {
-            continue
-        }
-        if tv.Key() != "" {
-            ef.tag = tv.Key()
-        }
-        ef.omitEmpty = tv.OmitEmpty()
-        fs = append(fs, ef)
-    }
-    fss := encodeFieldsSortType(fs)
-    sort.Sort(fss)
-    return fs
+		tv := getTag(f.Tag)
+		if tv.Ignore() {
+			continue
+		}
+		if tv.Key() != "" {
+			ef.tag = tv.Key()
+		}
+		ef.omitEmpty = tv.OmitEmpty()
+		fs = append(fs, ef)
+	}
+	fss := encodeFieldsSortType(fs)
+	sort.Sort(fss)
+	return fs
 }

--- a/bencode/encode_test.go
+++ b/bencode/encode_test.go
@@ -91,15 +91,15 @@ func TestRandomEncode(t *testing.T) {
 	}
 }
 func BenchmarkGetEncodeFields(b *testing.B) {
-    type TestStruct struct {
-        Field1 string `bencode:"field1"`
-        Field2 int    `bencode:"field2"`
-    }
-    testType := reflect.TypeOf(TestStruct{})
-    b.ResetTimer()
-    b.RunParallel(func(pb *testing.PB) {
-        for pb.Next() {
-            getEncodeFields(testType)
-        }
-    })
+	type TestStruct struct {
+		Field1 string `bencode:"field1"`
+		Field2 int    `bencode:"field2"`
+	}
+	testType := reflect.TypeOf(TestStruct{})
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			getEncodeFields(testType)
+		}
+	})
 }

--- a/bencode/encode_test.go
+++ b/bencode/encode_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"math/big"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -88,4 +89,17 @@ func TestRandomEncode(t *testing.T) {
 		assert.NoError(t, err, "%s", test)
 		assert.EqualValues(t, test.expected, string(data))
 	}
+}
+func BenchmarkGetEncodeFields(b *testing.B) {
+    type TestStruct struct {
+        Field1 string `bencode:"field1"`
+        Field2 int    `bencode:"field2"`
+    }
+    testType := reflect.TypeOf(TestStruct{})
+    b.ResetTimer()
+    b.RunParallel(func(pb *testing.PB) {
+        for pb.Next() {
+            getEncodeFields(testType)
+        }
+    })
 }


### PR DESCRIPTION
Replaced sync.Mutex and sync.RWMutex with sync.Map in decode/encode struct caching. This optimizes for read-heavy concurrent access by avoiding lock overhead, reducing execution time without increasing memory usage. Benchmarks below:

**Before**
```
encode_test.go
goos: darwin
goarch: arm64
pkg: github.com/james-lawrence/torrent/bencode
cpu: Apple M1 Pro
BenchmarkGetEncodeFields-10      7381923           167.3 ns/op         0 B/op          0 allocs/op
PASS
ok      github.com/james-lawrence/torrent/bencode   1.636s

decode_test.go
goos: darwin
goarch: arm64
pkg: github.com/james-lawrence/torrent/bencode
cpu: Apple M1 Pro
BenchmarkGetStructFieldForKey-10         8815094           138.8 ns/op         0 B/op          0 allocs/op
PASS
ok      github.com/james-lawrence/torrent/bencode   1.588s
```

**After**
```
encode_test.go
goos: darwin
goarch: arm64
pkg: github.com/james-lawrence/torrent/bencode
cpu: Apple M1 Pro
BenchmarkGetEncodeFields-10     1000000000           1.065 ns/op           0 B/op          0 allocs/op
PASS
ok      github.com/james-lawrence/torrent/bencode   1.433s 

decode_test.go
goos: darwin
goarch: arm64
pkg: github.com/james-lawrence/torrent/bencode
cpu: Apple M1 Pro
BenchmarkGetStructFieldForKey-10        445837135            2.583 ns/op           0 B/op          0 allocs/op
PASS
ok      github.com/james-lawrence/torrent/bencode   1.673s
```