### PR TITLE
maanas/btprotocol-bitfield: preallocate bitfield and extended payload

### DIFF
--- a/btprotocol/decoder.go
+++ b/btprotocol/decoder.go
@@ -124,14 +124,14 @@ func readByte(r io.Reader) (b byte, err error) {
 }
 
 func unmarshalBitfield(b []byte) (bf []bool) {
-    length := len(b) * 8
-    bf = make([]bool, length)
-    idx := 0
-    for _, c := range b {
-        for i := 7; i >= 0; i-- {
-            bf[idx] = (c >> uint(i)) & 1 == 1
-            idx++
-        }
-    }
-    return
+	length := len(b) * 8
+	bf = make([]bool, length)
+	idx := 0
+	for _, c := range b {
+		for i := 7; i >= 0; i-- {
+			bf[idx] = (c >> uint(i)) & 1 == 1
+			idx++
+		}
+	}
+	return
 }

--- a/btprotocol/decoder_test.go
+++ b/btprotocol/decoder_test.go
@@ -92,68 +92,68 @@ func TestDecodeOverlongPiece(t *testing.T) {
 	require.Error(t, d.Decode(&m))
 }
 func BenchmarkDecodeBitfield(b *testing.B) {
-    r, w := io.Pipe()
-    const bitfieldLen = 128 * 1024
-    bitfieldData := make([]byte, bitfieldLen)
-    msgLen := uint32(1 + bitfieldLen)
-    var lenBuf [4]byte
-    binary.BigEndian.PutUint32(lenBuf[:], msgLen)
-    data := append(lenBuf[:], byte(Bitfield))
-    data = append(data, bitfieldData...)
-    b.SetBytes(int64(len(data)))
-    b.ReportAllocs()
-    defer r.Close()
-    go func() {
-        defer w.Close()
-        for {
-            n, err := w.Write(data)
-            if err == io.ErrClosedPipe {
-                return
-            }
-            require.NoError(b, err)
-            require.Equal(b, len(data), n)
-        }
-    }()
-    d := Decoder{
-        R:         bufio.NewReader(r),
-        MaxLength: 1 << 18,
-    }
-    for i := 0; i < b.N; i++ {
-        var msg Message
-        require.NoError(b, d.Decode(&msg))
-    }
+	r, w := io.Pipe()
+	const bitfieldLen = 128 * 1024
+	bitfieldData := make([]byte, bitfieldLen)
+	msgLen := uint32(1 + bitfieldLen)
+	var lenBuf [4]byte
+	binary.BigEndian.PutUint32(lenBuf[:], msgLen)
+	data := append(lenBuf[:], byte(Bitfield))
+	data = append(data, bitfieldData...)
+	b.SetBytes(int64(len(data)))
+	b.ReportAllocs()
+	defer r.Close()
+	go func() {
+		    defer w.Close()
+		    for {
+		        n, err := w.Write(data)
+		        if err == io.ErrClosedPipe {
+		            return
+		        }
+	        require.NoError(b, err)
+	        require.Equal(b, len(data), n)
+	    }
+	}()
+	d := Decoder{
+		R:         bufio.NewReader(r),
+		MaxLength: 1 << 18,
+	}
+	for i := 0; i < b.N; i++ {
+		var msg Message
+		require.NoError(b, d.Decode(&msg))
+	}
 }
 
 func BenchmarkDecodeExtended(b *testing.B) {
-    r, w := io.Pipe()
-    const payloadLen = 128 * 1024
-    payloadData := make([]byte, payloadLen)
-    msgLen := uint32(1 + 1 + payloadLen)
-    var lenBuf [4]byte
-    binary.BigEndian.PutUint32(lenBuf[:], msgLen)
-    data := append(lenBuf[:], byte(Extended))
-    data = append(data, byte(0))
-    data = append(data, payloadData...)
-    b.SetBytes(int64(len(data)))
-    b.ReportAllocs()
-    defer r.Close()
-    go func() {
-        defer w.Close()
-        for {
-            n, err := w.Write(data)
-            if err == io.ErrClosedPipe {
-                return
-            }
-            require.NoError(b, err)
-            require.Equal(b, len(data), n)
-        }
-    }()
-    d := Decoder{
-        R:         bufio.NewReader(r),
-        MaxLength: 1 << 18,
-    }
-    for i := 0; i < b.N; i++ {
-        var msg Message
-        require.NoError(b, d.Decode(&msg))
-    }
+	r, w := io.Pipe()
+	const payloadLen = 128 * 1024
+	payloadData := make([]byte, payloadLen)
+	msgLen := uint32(1 + 1 + payloadLen)
+	var lenBuf [4]byte
+	binary.BigEndian.PutUint32(lenBuf[:], msgLen)
+	data := append(lenBuf[:], byte(Extended))
+	data = append(data, byte(0))
+	data = append(data, payloadData...)
+	b.SetBytes(int64(len(data)))
+	b.ReportAllocs()
+	defer r.Close()
+	go func() {
+		defer w.Close()
+		for {
+			n, err := w.Write(data)
+			if err == io.ErrClosedPipe {
+				return
+			}
+			require.NoError(b, err)
+			require.Equal(b, len(data), n)
+		}
+		}()
+		d := Decoder{
+			R:         bufio.NewReader(r),
+			MaxLength: 1 << 18,
+		}
+		for i := 0; i < b.N; i++ {
+			var msg Message
+			require.NoError(b, d.Decode(&msg))
+	}
 }


### PR DESCRIPTION
Preallocated slices in unmarshalBitfield and switched io.ReadAll to io.ReadFull in Decode for Extended messages. Benchmark below:

**Before**

```
goos: darwin
goarch: arm64
pkg: github.com/james-lawrence/torrent/btprotocol
cpu: Apple M1 Pro
BenchmarkDecodeBitfield-10          1449        877659 ns/op     149.35 MB/s     5373023 B/op         43 allocs/op
PASS
ok      github.com/james-lawrence/torrent/btprotocol    2.595s

goos: darwin
goarch: arm64
pkg: github.com/james-lawrence/torrent/btprotocol
cpu: Apple M1 Pro
BenchmarkDecodeExtended-10         18334         67085 ns/op    1953.91 MB/s      686423 B/op         25 allocs/op
PASS
ok      github.com/james-lawrence/torrent/btprotocol    2.115s
```

**After**

```
goos: darwin
goarch: arm64
pkg: github.com/james-lawrence/torrent/btprotocol
cpu: Apple M1 Pro
BenchmarkDecodeBitfield-10          1567        792870 ns/op     165.32 MB/s     1179896 B/op          7 allocs/op
PASS
ok      github.com/james-lawrence/torrent/btprotocol    2.532s

goos: darwin
goarch: arm64
pkg: github.com/james-lawrence/torrent/btprotocol
cpu: Apple M1 Pro
BenchmarkDecodeExtended-10         95728         11966 ns/op    10954.15 MB/s     131129 B/op          7 allocs/op
PASS
ok      github.com/james-lawrence/torrent/btprotocol    1.493s
```
