### PR TITLE
perf(torrent): NewFromInfoFile using raw bytes

### DIFF
--- a/metadata.go
+++ b/metadata.go
@@ -1,6 +1,7 @@
 package torrent
 
 import (
+	"bytes"
 	"io"
 	"math/rand/v2"
 	"os"
@@ -132,21 +133,23 @@ func New(info metainfo.Hash, options ...Option) (t Metadata, err error) {
 	return t, nil
 }
 
-// NewFromMetaInfoFile loads torrent info stored in a file.
+// NewFromInfoFile loads torrent info stored in a file.
 func NewFromInfoFile(path string, options ...Option) (t Metadata, err error) {
-	src, err := os.Open(path)
-	if err != nil {
-		return t, errorsx.Wrapf(err, "unable to load info from %s", path)
-	}
-	defer src.Close()
+    raw, err := os.ReadFile(path)
+    if err != nil {
+        return t, errorsx.Wrapf(err, "unable to load info from %s", path)
+    }
 
-	tinfo, err := metainfo.NewInfoFromReader(src)
-	if err != nil {
-		return t, errorsx.Wrapf(err, "unable to load info from %s", path)
-	}
+    var tinfo metainfo.Info
+    decoder := bencode.NewDecoder(bytes.NewReader(raw))
+    if err = decoder.Decode(&tinfo); err != nil {
+        return t, errorsx.Wrapf(err, "unable to decode info from %s", path)
+    }
 
-	t, err = NewFromInfo(tinfo, options...)
-	return t, errorsx.Wrapf(err, "unable to load info from %s", path)
+    return New(
+        metainfo.NewHashFromBytes(raw),
+        append(options, OptionInfo(raw), OptionDisplayName(tinfo.Name))...,
+    )
 }
 
 // NewFromMetaInfoFile loads torrent metadata stored in a file.


### PR DESCRIPTION
Avoid re-encoding the info dictionary in NewFromInfoFile; read raw bytes directly for InfoBytes and hashing, decoding only for the name. Bigger gains on larger torrents. 

**Before**

```
 metadata_test.go
goos: darwin
goarch: arm64
pkg: github.com/james-lawrence/torrent
cpu: Apple M1 Pro
BenchmarkNewFromInfoFile-10            8     127976812 ns/op     7837382 B/op     150075 allocs/op
PASS
ok      github.com/james-lawrence/torrent   2.384s
```



**After**

```
metadata_test.go

goos: darwin
goarch: arm64
pkg: github.com/james-lawrence/torrent
cpu: Apple M1 Pro
BenchmarkNewFromInfoFile-10          117      10015415 ns/op     6313774 B/op     150059 allocs/op
PASS
ok      github.com/james-lawrence/torrent   2.229s
```
