### PR TITLE
perf(storage): multi-file torrent IO with precomputation and binary search

### DIFF
--- a/storage/file.go
+++ b/storage/file.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"sync/atomic"
 
 	"github.com/james-lawrence/torrent/internal/langx"
@@ -48,7 +49,6 @@ func fixedPathMaker(name string) FilePathMaker {
 }
 
 func InfoHashPathMaker(baseDir string, infoHash metainfo.Hash, info *metainfo.Info, fi *metainfo.FileInfo) string {
-	// s := filepath.Join(baseDir, infoHash.String(), langx.DefaultIfZero(langx.DerefOrZero(info).Name, filepath.Join(langx.DerefOrZero(fi).Path...)))
 	s := filepath.Join(baseDir, infoHash.String(), filepath.Join(langx.DerefOrZero(fi).Path...))
 	return s
 }
@@ -70,24 +70,59 @@ func (me *fileClientImpl) Close() error {
 }
 
 func (fs *fileClientImpl) OpenTorrent(info *metainfo.Info, infoHash metainfo.Hash) (TorrentImpl, error) {
-	err := CreateNativeZeroLengthFiles(fs.baseDir, infoHash, info, fs.pathMaker)
-	if err != nil {
+	upverted := info.UpvertedFiles()
+	entries := make([]fileEntry, len(upverted))
+	begin := int64(0)
+	for i, fi := range upverted {
+		path := fs.pathMaker(fs.baseDir, infoHash, info, &fi)
+		entries[i] = fileEntry{
+			path:   path,
+			begin:  begin,
+			length: fi.Length,
+		}
+		begin += fi.Length
+	}
+
+	if err := createAllDirectories(entries); err != nil {
 		return nil, err
 	}
+
+	if err := CreateNativeZeroLengthFiles(fs.baseDir, infoHash, info, fs.pathMaker); err != nil {
+		return nil, err
+	}
+
 	return &fileTorrentImpl{
-		dir:       fs.baseDir,
-		info:      info,
-		infoHash:  infoHash,
-		pathMaker: fs.pathMaker,
+		closed:      atomic.Bool{},
+		info:        info,
+		infoHash:    infoHash,
+		pathMaker:   fs.pathMaker,
+		files:       entries,
+		totalLength: begin,
 	}, nil
 }
 
+type fileEntry struct {
+	path   string
+	begin  int64
+	length int64
+}
+
+func createAllDirectories(entries []fileEntry) error {
+	for _, e := range entries {
+		if err := os.MkdirAll(filepath.Dir(e.path), 0777); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 type fileTorrentImpl struct {
-	closed    atomic.Bool
-	dir       string
-	info      *metainfo.Info
-	infoHash  metainfo.Hash
-	pathMaker FilePathMaker
+	closed      atomic.Bool
+	info        *metainfo.Info
+	infoHash    metainfo.Hash
+	pathMaker   FilePathMaker
+	files       []fileEntry
+	totalLength int64
 }
 
 // ReadAt implements TorrentImpl.
@@ -121,10 +156,6 @@ func CreateNativeZeroLengthFiles(dir string, infohash metainfo.Hash, info *metai
 		}
 
 		name := pathMaker(dir, infohash, info, &fi)
-		if err := os.MkdirAll(filepath.Dir(name), 0777); err != nil {
-			return err
-		}
-
 		var f io.Closer
 		if f, err = os.OpenFile(name, os.O_RDONLY|os.O_CREATE, 0600); err != nil {
 			return err
@@ -157,82 +188,83 @@ func (t *fileTorrentImplIO) reader(path string) (ioreadatclose, error) {
 }
 
 // Returns EOF on short or missing file.
-func (t *fileTorrentImplIO) readFileAt(fi metainfo.FileInfo, b []byte, off int64) (n int, err error) {
-	filepath := t.fts.pathMaker(t.fts.dir, t.fts.infoHash, t.fts.info, &fi)
-
-	f, err := t.reader(filepath)
+func (t *fileTorrentImplIO) readFileAt(fe fileEntry, b []byte, off int64) (n int, err error) {
+	f, err := t.reader(fe.path)
 	if err != nil {
 		return 0, err
 	}
 	defer f.Close()
 
-	// Limit the read to within the expected bounds of this file.
-	if int64(len(b)) > fi.Length-off {
-		b = b[:fi.Length-off]
-	}
-
-	return io.ReadFull(io.NewSectionReader(f, off, int64(len(b))), b)
+	return io.ReadFull(io.NewSectionReader(f, off, fe.length-off), b)
 }
 
 // Only returns EOF at the end of the torrent. Premature EOF is ErrUnexpectedEOF.
 func (t fileTorrentImplIO) ReadAt(b []byte, off int64) (n int, err error) {
-	for _, fi := range t.fts.info.UpvertedFiles() {
-		for off < fi.Length {
-			n1, err1 := t.readFileAt(fi, b, off)
-			n += n1
-			off += int64(n1)
-			b = b[n1:]
-			if len(b) == 0 {
-				// Got what we need.
-				return
-			}
-			if n1 != 0 {
-				// Made progress.
-				continue
-			}
-			err = err1
-			if err == io.EOF {
-				// Lies.
-				err = io.ErrUnexpectedEOF
-			}
-			return n, err
-		}
-		off -= fi.Length
+	if off >= t.fts.totalLength {
+		return 0, io.EOF
 	}
 
+	// Find the starting file using binary search.
+	startFile := sort.Search(len(t.fts.files), func(i int) bool {
+		return t.fts.files[i].begin > off
+	}) - 1
+
+	for i := startFile; i < len(t.fts.files) && len(b) > 0; i++ {
+		fe := t.fts.files[i]
+		localOff := off - fe.begin
+		requested := min(int64(len(b)), fe.length-localOff)
+		var n1 int
+		n1, err = t.readFileAt(fe, b[:requested], localOff)
+		n += n1
+		off += int64(n1)
+		b = b[n1:]
+		if err != nil {
+			return n, err
+		}
+		if int64(n1) < requested {
+			return n, io.ErrUnexpectedEOF
+		}
+	}
+	if len(b) == 0 {
+		return n, nil
+	}
 	return n, io.EOF
 }
 
 func (t fileTorrentImplIO) WriteAt(p []byte, off int64) (n int, err error) {
-	for _, fi := range t.fts.info.UpvertedFiles() {
-		if off >= fi.Length {
-			off -= fi.Length
-			continue
-		}
-		n1 := len(p)
-		if int64(n1) > fi.Length-off {
-			n1 = int(fi.Length - off)
-		}
-		name := t.fts.pathMaker(t.fts.dir, t.fts.infoHash, t.fts.info, &fi)
-		os.MkdirAll(filepath.Dir(name), 0777)
-		var f *os.File
-		f, err = os.OpenFile(name, os.O_WRONLY|os.O_CREATE, 0666)
-		if err != nil {
-			return
-		}
+	// Find the starting file using binary search.
+	startFile := sort.Search(len(t.fts.files), func(i int) bool {
+		return t.fts.files[i].begin > off
+	}) - 1
 
-		n1, err = f.WriteAt(p[:n1], off)
-		// TODO: On some systems, write errors can be delayed until the Close.
+	for i := startFile; i < len(t.fts.files) && len(p) > 0; i++ {
+		fe := t.fts.files[i]
+		localOff := off - fe.begin
+		n1 := min(int64(len(p)), fe.length-localOff)
+		var f *os.File
+		f, err = os.OpenFile(fe.path, os.O_WRONLY|os.O_CREATE, 0666)
+		if err != nil {
+			return n, err
+		}
+		var nw int
+		nw, err = f.WriteAt(p[:n1], localOff)
 		f.Close()
 		if err != nil {
-			return
+			return n, err
 		}
-		n += n1
-		off = 0
-		p = p[n1:]
-		if len(p) == 0 {
-			break
+		if int64(nw) < n1 {
+			return n, io.ErrShortWrite
 		}
+		n += nw
+		off += int64(nw)
+		p = p[nw:]
 	}
-	return
+	return n, nil
+}
+
+func min(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
 }


### PR DESCRIPTION
1. Precomputing file paths and cumulative offsets in OpenTorrent to eliminate repeated path construction and linear scans during IO.
2. binary search in ReadAt and WriteAt to locate the starting file for a given offset, reducing time complexity from O(n) to O(log n)
3. Pre-creating all directories upfront in OpenTorrent to avoid redundant syscalls during writes.

**Before**
```
file_test.go
goos: darwin
goarch: arm64
pkg: github.com/james-lawrence/torrent/storage
cpu: Apple M1 Pro
BenchmarkFileStorage/WriteAtLastByte-10                   55      23473835 ns/op    67110972 B/op    1048590 allocs/op
PASS
ok      github.com/james-lawrence/torrent/storage   1.706s
```

**After**
```
file_test.go
goos: darwin
goarch: arm64
pkg: github.com/james-lawrence/torrent/storage
cpu: Apple M1 Pro
BenchmarkFileStorage/WriteAtLastByte-10                65466         18335 ns/op         248 B/op          3 allocs/op
PASS
ok      github.com/james-lawrence/torrent/storage   4.733s
```